### PR TITLE
Added jitter based incremental backoff feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,28 @@ The version with 2 arguments specifies a ceiling to the value:
     5> backoff:increment(backoff:increment(backoff:increment(2)), 10).
     10
 
+## Simple Backoffs with jitter
+
+Jitter based incremental backoffs increase the back off period for each retry attempt using a randomization function that grows exponentially. They work by calling the functions `rand_increment/1-2`. The function with one argument will grow in an unbounded manner:
+
+    1> backoff:rand_increment(1).
+    3
+    2> backoff:rand_increment(backoff:rand_increment(1)).
+    7
+    3> backoff:rand_increment(backoff:rand_increment(backoff:rand_increment(1))).
+    19
+    4> backoff:rand_increment(backoff:rand_increment(backoff:rand_increment(1))).
+    14
+    5> backoff:rand_increment(backoff:rand_increment(backoff:rand_increment(1))).
+    17
+
+The version with 2 arguments specifies a ceiling to the value:
+
+    6> backoff:rand_increment(backoff:rand_increment(backoff:rand_increment(2))).
+    21
+    7> backoff:rand_increment(backoff:rand_increment(backoff:rand_increment(2)), 10).
+    10
+
 ## State Backoffs
 
 State backoffs keep track of the current value, the initial value, and the
@@ -84,6 +106,28 @@ If what you want are unbound exponential backoffs, you can initiate them with:
     14> backoff:init(Start, 'infinity').
 
 And still use them as usual. The increments will have no upper limit.
+
+## State Backoffs with jitter
+
+You can enable a jitter based incremental backoff by calling `type/2`
+that swaps the state of the backoff:
+
+    1> B0 = backoff:init(2, 30).
+    {backoff,2,30,2,normal,undefined,undefined}
+    2> B1 = backoff:type(B0, jitter).
+    {backoff,2,30,2,jitter,undefined,undefined}
+    3> {_, B2} = backoff:fail(B1).
+    {7, ...}
+    4> {_, B3} = backoff:fail(B2).
+    {12, ...}
+
+Calling `type/2` with argument `normal` will swap the backoff state back
+to its default behavior:
+
+    5> B4 = backoff:type(B3, normal).
+    {backoff,2,30,12,normal,undefined,undefined}
+    6> {_, B5} = backoff:fail(B4).
+    {24, ...}
 
 ## Timeout Events
 
@@ -129,5 +173,5 @@ operations.
 
 # Changelog
 
+- 1.1.0: added jitter based incremental backoff
 - 1.0.0: initial commit stable for over a year
-- 0.1.0: initial commit

--- a/src/backoff.app.src
+++ b/src/backoff.app.src
@@ -1,6 +1,6 @@
 {application, backoff,
  [{description, "Exponential backoffs library"},
-  {vsn, "1.0.0"},
+  {vsn, "1.1.0"},
   {applications, [stdlib, kernel]},
   {registered, []}
 ]}.

--- a/src/backoff.erl
+++ b/src/backoff.erl
@@ -1,10 +1,14 @@
 -module(backoff).
 -export([increment/1, increment/2]).
+-export([rand_increment/1, rand_increment/2]).
+-export([type/2]).
 -export([init/2, init/4,
          fire/1, get/1, succeed/1, fail/1]).
+
 -record(backoff, {start :: pos_integer(),
                   max :: pos_integer() | infinity,
                   current :: pos_integer(),
+                  type=normal :: normal | jitter,
                   value :: term(),
                   dest :: pid()}).
 
@@ -20,6 +24,21 @@ increment(N) when is_integer(N) -> N bsl 1.
     N :: pos_integer(),
     Max :: pos_integer().
 increment(N, Max) -> min(increment(N), Max).
+
+%% Just do the random increments by hand!
+%% Algorithm inspired in the Google HTTP Java client implementation of Class ExponentialBackOff.
+%% See: http://javadoc.google-http-java-client.googlecode.com/hg/1.18.0-rc/com/google/api/client/util/ExponentialBackOff.html
+-spec rand_increment(pos_integer()) -> pos_integer().
+rand_increment(N) ->
+    RandFactor = application:get_env(?MODULE, rand_factor, 0.5),
+    DefMultiplier = application:get_env(?MODULE, def_multiplier, 1.5),
+    Rand = 1 - RandFactor + random:uniform(),
+    erlang:round(increment(N) * DefMultiplier * Rand).
+
+-spec rand_increment(N, Max) -> pos_integer() when
+    N :: pos_integer(),
+    Max :: pos_integer().
+rand_increment(N, Max) -> min(rand_increment(N), Max).
 
 %% Increments + Timer support
 
@@ -52,16 +71,36 @@ fire(#backoff{current=Delay, value=Value, dest=Dest}) ->
 -spec get(backoff()) -> pos_integer().
 get(#backoff{current=Delay}) -> Delay.
 
+%% Swaps between the states of the backoff.
+-spec type(backoff(), normal | jitter) -> backoff().
+type(#backoff{}=B, jitter) ->
+    maybe_seed(),
+    B#backoff{type=jitter};
+type(#backoff{}=B, normal) ->
+    B#backoff{type=normal}.
+
 -spec fail(backoff()) -> {New::pos_integer(), backoff()}.
-fail(B=#backoff{current=Delay, max=infinity}) ->
+fail(B=#backoff{current=Delay, max=infinity, type=normal}) ->
     NewDelay = increment(Delay),
     {NewDelay, B#backoff{current=NewDelay}};
-fail(B=#backoff{current=Delay, max=Max}) ->
+fail(B=#backoff{current=Delay, max=Max, type=normal}) ->
     NewDelay = increment(Delay, Max),
+    {NewDelay, B#backoff{current=NewDelay}};
+fail(B=#backoff{current=Delay, max=infinity, type=jitter}) ->
+    NewDelay = rand_increment(Delay),
+    {NewDelay, B#backoff{current=NewDelay}};
+fail(B=#backoff{current=Delay, max=Max, type=jitter}) ->
+    NewDelay = rand_increment(Delay, Max),
     {NewDelay, B#backoff{current=NewDelay}}.
+
 
 -spec succeed(backoff()) -> {New::pos_integer(), backoff()}.
 succeed(B=#backoff{start=Start}) ->
     {Start, B#backoff{current=Start}}.
 
-
+maybe_seed() ->
+    case erlang:get(random_seed) of
+        undefined -> random:seed(erlang:now());
+        {X,X,X} -> random:seed(erlang:now());
+        _ -> ok
+    end.

--- a/test/prop_backoff.erl
+++ b/test/prop_backoff.erl
@@ -19,6 +19,24 @@ prop_increment_ceiled_increases() ->
              (backoff:increment(X,Y) =:= X andalso X =:= Y))
      )).
 
+%% random increment operations are always returning bigger
+%% and bigger values, assuming positive integers
+prop_rand_increment_increases() ->
+    ?FORALL(X, pos_integer(),
+        backoff:rand_increment(X) > X).
+
+%% random increments should never go higher than the max
+%% value allowed.
+prop_rand_increment_ceiled_increases() ->
+    ?FORALL({X,Y}, backoff_range(),
+        ?WHENFAIL(io:format("~p~n",[{X,Y,backoff:rand_increment(X,Y)}]),
+            backoff:rand_increment(X,Y) =< Y
+            andalso
+            (backoff:rand_increment(X,Y) > X
+             orelse
+             (backoff:rand_increment(X,Y) =:= X andalso X =:= Y))
+     )).
+
 %% increments from an init value always go higher when unbound
 prop_fail_increases() ->
     ?FORALL(S0, backoff_infinity(),


### PR DESCRIPTION
Feature inspired in the [Google HTTP Java client implementation of Class ExponentialBackOff]( http://javadoc.google-http-java-client.googlecode.com/hg/1.18.0-rc/com/google/api/client/util/ExponentialBackOff.html).

This change includes the new functions `rand_increment/1-2` and `jitter/1`. See updated `README.md` and implementation for further details.