### PR TITLE
Fix jitter backoff to always use uniform interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ Jitter based incremental backoffs increase the back off period for each retry at
     5> backoff:rand_increment(backoff:rand_increment(backoff:rand_increment(1))).
     17
 
-The version with 2 arguments specifies a ceiling to the value:
+The version with 2 arguments specifies a ceiling to the value. If the
+delay is close to the ceiling the new delay will also be close to the
+ceiling and may be less than the previous delay.
 
     6> backoff:rand_increment(backoff:rand_increment(backoff:rand_increment(2))).
     21

--- a/test/prop_backoff_statem.erl
+++ b/test/prop_backoff_statem.erl
@@ -1,0 +1,62 @@
+-module(prop_backoff_statem).
+-include_lib("proper/include/proper.hrl").
+
+-export([initial_state/0]).
+-export([command/1]).
+-export([precondition/2]).
+-export([next_state/3]).
+-export([postcondition/3]).
+
+-record(state, {backoff, type=normal, delay, failures=0, start, max}).
+
+init_args() ->
+    ?SUCHTHAT([X,Y], [pos_integer(), oneof([pos_integer(), infinity])],
+              X < Y).
+type() ->
+    elements([normal, jitter]).
+
+initial_state() ->
+    #state{}.
+
+command(#state{backoff=undefined}) ->
+    {call, backoff, init, init_args()};
+command(#state{backoff=B}) ->
+    oneof([{call, backoff, type, [B, type()]},
+           {call, backoff, fail, [B]},
+           {call, backoff, succeed, [B]},
+           {call, backoff, get, [B]}]).
+
+precondition(#state{backoff=B}, {call, _, init, _}) ->
+    B =:= undefined;
+precondition(#state{backoff=B}, _) ->
+    B =/= undefined.
+
+next_state(State, B, {call, _, init, [Start, Max]}) ->
+    State#state{backoff=B, delay= Start, start=Start, max=Max};
+next_state(#state{start=Start} = State, Value, {call, _, succeed, _}) ->
+    NewB = {call, erlang, element, [2, Value]},
+    State#state{backoff=NewB, delay=Start, failures=0};
+next_state(#state{failures=N} = State, Value, {call, _, fail, _}) ->
+    NewDelay = {call, erlang, element, [1, Value]},
+    NewB = {call, erlang, element, [2, Value]},
+    State#state{backoff=NewB, delay=NewDelay, failures=N+1};
+next_state(State, NewB, {call, _, type, [_, Type]}) ->
+    State#state{backoff=NewB, type=Type};
+next_state(State, _, {call, _, get, _}) ->
+    State.
+
+postcondition(#state{start=Start}, {call, _, succeed, _}, {NewDelay, _}) ->
+    NewDelay =:= Start;
+postcondition(#state{type=normal, delay=Delay, max=Max}, {call, _, fail, _},
+              {NewDelay, _}) ->
+    (NewDelay > Delay andalso NewDelay =< Max) orelse
+    (NewDelay =:= Delay andalso NewDelay =:= Max);
+postcondition(#state{type=jitter, delay=Delay, max=Max}, {call, _, fail, _},
+              {NewDelay, _}) ->
+    (NewDelay >= Delay orelse
+     (Delay > Max div 3 andalso NewDelay >= 1 andalso NewDelay >= Max div 3))
+    andalso NewDelay =< Max;
+postcondition(#state{delay=Delay}, {call, _, get, _}, Result) ->
+    Result =:= Delay;
+postcondition(_, _, _) ->
+    true.


### PR DESCRIPTION
This algorithm is much simpler. It uses normal exponential backoff and then chooses a value in an interval around it. This solves the synchronisation issue experienced once jitter delay reaches its ceiling in #8.

Replaces #9 and includes its property test.

Jitter backoff now increases the backoff using a similar algorithm to normal, except that the new delay is chosen uniformly from an interval around the increment:
```erlang
{0.5 * backoff:increment(N), 1.5 * backoff:increment(N)}
```
When a ceiling value (`Max`) is used the interval and the delay is above `Max div 3` the following interval is used:
```erlang
{Max div 3, Max}
```
This means that once a delay is above `Max div 3` all subsequent delays will be from that interval.

The values 0.5 and 1.5 are suggested as a simple way to prevent synchronisation in:
The Synchronization of Periodic Routing Messages, Sally Floyd and Van Jacobson, 1994, http://ee.lbl.gov/papers/sync_94.pdf

Jitter nolonger uses application env `rand_factor` and `def_multiplier`. Should these be kept or not? It would seem that `def_multiplier` should also apply to normal exponential backoff if it remains. By hard coding the values the code is much clearer and I am unsure if different values would be desired given the new approach.