### PR TITLE
Replace erlang:now with random:seed doc example.

### DIFF
--- a/src/backoff.erl
+++ b/src/backoff.erl
@@ -112,7 +112,14 @@ succeed(B=#backoff{start=Start}) ->
 
 maybe_seed() ->
     case erlang:get(random_seed) of
-        undefined -> random:seed(erlang:now());
-        {X,X,X} -> random:seed(erlang:now());
+        undefined -> random:seed(
+                      erlang:phash2([node()]),
+                      erlang:monotonic_time(),
+                      erlang:unique_integer());
+        {X,X,X} -> random:seed(
+                      erlang:phash2([node()]),
+                      erlang:monotonic_time(),
+                      erlang:unique_integer());
+
         _ -> ok
     end.


### PR DESCRIPTION
Hiya,

This just silences the compiler warnings about `erlang:now/0` being deprecated on Erlang/OTP 18. I replaced it with the documentation example from `random:seed/3`.

Thanks!