### PR TITLE
Add prop_backoff_statem to test instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ everything needed:
     Erlang R16B (erts-5.10.1) [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false]
     
     Eshell V5.10.1  (abort with ^G)
-    1> c("test/prop_backoff"), proper:module(prop_backoff).
+    1> c("test/prop_backoff"), c("test/prop_backoff_statem"), proper:module(prop_backoff).
     ...
     []
 


### PR DESCRIPTION
Hiya,

This just fixes the 'run the tests' recipe so that they run right off (as written, they crash looking for `initial_state/0`, since `prop_backoff_statem` hasn't been compiled). There's likely a smarter solution, but I'm still finding my way with Erlang a bit, and I just wanted to make sure the tests still passed with my change in https://github.com/ferd/backoff/pull/14.

Thanks!