### PR TITLE
fix dialyzer warning for init/2

### DIFF
--- a/src/backoff.erl
+++ b/src/backoff.erl
@@ -10,7 +10,7 @@
                   current :: pos_integer(),
                   type=normal :: normal | jitter,
                   value :: term(),
-                  dest :: pid()}).
+                  dest :: pid() | undefined }).
 
 -opaque backoff() :: #backoff{}.
 


### PR DESCRIPTION
dialyzer warns because the state record only accepts pids.